### PR TITLE
resubscribe functionality via API

### DIFF
--- a/src/Api/ZohoCampaignsApi.php
+++ b/src/Api/ZohoCampaignsApi.php
@@ -64,6 +64,63 @@ class ZohoCampaignsApi
             ->json();
     }
 
+    /**
+     * Retrieves the list of subscribers for a given list key with various options.
+     *
+     * @param string $listKey The list key.
+     * @param array $options An array of options for the request. Possible keys include:
+     *     - 'sort': The sort order of the results. Possible values are 'asc' for ascending order and 'desc' for descending order.
+     *     - 'fromindex': The starting index for the results. This is a number.
+     *     - 'range': The range of results to retrieve. This is a number.
+     *     - 'status': The status of the subscribers to retrieve. Possible values are 'active', 'recent', 'mostrecent', 'unsub', and 'bounce'.
+     * @return array The list of subscribers.
+     */
+    public function getListSubscribers(string $listKey, array $options = []): array
+    {
+        $params = array_merge([
+            'listkey' => $listKey,
+            'resfmt' => 'JSON',
+        ], $options);
+
+        $response = Http::baseUrl($this->endpoint())
+            ->withToken($this->accessToken->get(), 'Zoho-oauthtoken')
+            ->withHeaders([
+                'Content-Type' => 'application/x-www-form-urlencoded',
+            ])
+            ->get(sprintf('/json/getlistsubscribers?%s', http_build_query($params)))
+            ->json();
+
+        return $response['list_of_details'] ?? [];
+    }
+
+
+    /**
+     * Retrieves the count of subscribers for a given list key and status.
+     *
+     * @param string $listKey The list key.
+     * @param string $status The status of the subscribers to count. Possible values are 'active', 'unsub', 'bounce', and 'spam'.
+     * @return int The count of subscribers.
+     */
+    public function getListSubscribersCount(string $listKey, string $status='active'): int
+    {
+        $params = [
+            'listkey' => $listKey,
+            'resfmt' => 'JSON',
+            'status' => $status,
+        ];
+
+        $response = Http::baseUrl($this->endpoint())
+            ->withToken($this->accessToken->get(), 'Zoho-oauthtoken')
+            ->withHeaders([
+                'Content-Type' => 'application/x-www-form-urlencoded',
+            ])
+            ->get(sprintf('/json/listsubscriberscount?%s', http_build_query($params)))
+            ->json();
+
+        return $response['no_of_contacts'] ?? 0;
+    }
+
+
     protected function endpoint(): string
     {
         return sprintf('https://campaigns.%s/api/v1.1', $this->region->domain());

--- a/src/Api/ZohoCampaignsApi.php
+++ b/src/Api/ZohoCampaignsApi.php
@@ -29,7 +29,7 @@ class ZohoCampaignsApi
             ], $contactInfo)),
         ], $additionalParams);
         
-        dump($params);
+        dump(http_build_query($params));
 
         return Http::baseUrl($this->endpoint())
             ->withToken($this->accessToken->get(), 'Zoho-oauthtoken')

--- a/src/Api/ZohoCampaignsApi.php
+++ b/src/Api/ZohoCampaignsApi.php
@@ -87,8 +87,10 @@ class ZohoCampaignsApi
             ->withHeaders([
                 'Content-Type' => 'application/x-www-form-urlencoded',
             ])
-            ->get(sprintf('/json/getlistsubscribers?%s', http_build_query($params)))
+            ->get(sprintf('/getlistsubscribers?%s', http_build_query($params)))
             ->json();
+        
+        dump($response);
 
         return $response['list_of_details'] ?? [];
     }
@@ -114,9 +116,10 @@ class ZohoCampaignsApi
             ->withHeaders([
                 'Content-Type' => 'application/x-www-form-urlencoded',
             ])
-            ->get(sprintf('/json/listsubscriberscount?%s', http_build_query($params)))
+            ->get(sprintf('/listsubscriberscount?%s', http_build_query($params)))
             ->json();
-
+        
+            dump($response);
         return $response['no_of_contacts'] ?? 0;
     }
 

--- a/src/Api/ZohoCampaignsApi.php
+++ b/src/Api/ZohoCampaignsApi.php
@@ -28,8 +28,6 @@ class ZohoCampaignsApi
                 'Contact Email' => $email,
             ], $contactInfo)),
         ], $additionalParams);
-        
-        dump(http_build_query($params));
 
         return Http::baseUrl($this->endpoint())
             ->withToken($this->accessToken->get(), 'Zoho-oauthtoken')

--- a/src/Api/ZohoCampaignsApi.php
+++ b/src/Api/ZohoCampaignsApi.php
@@ -19,16 +19,16 @@ class ZohoCampaignsApi
      *     code: int,
      * }
      */
-    public function listSubscribe(string $listKey, string $email, array $contactInfo = []): array
+    public function listSubscribe(string $listKey, string $email, array $contactInfo = [], array $additionalParams = []): array
     {
-        $params = [
+        $params = array_merge([
             'listkey' => $listKey,
             'resfmt' => 'JSON',
             'contactinfo' => json_encode(array_merge([
                 'Contact Email' => $email,
             ], $contactInfo)),
-        ];
-
+        ], $additionalParams);
+    
         return Http::baseUrl($this->endpoint())
             ->withToken($this->accessToken->get(), 'Zoho-oauthtoken')
             ->withHeaders([

--- a/src/Api/ZohoCampaignsApi.php
+++ b/src/Api/ZohoCampaignsApi.php
@@ -89,8 +89,6 @@ class ZohoCampaignsApi
             ])
             ->get(sprintf('/getlistsubscribers?%s', http_build_query($params)))
             ->json();
-        
-        dump($response);
 
         return $response['list_of_details'] ?? [];
     }
@@ -119,7 +117,6 @@ class ZohoCampaignsApi
             ->get(sprintf('/listsubscriberscount?%s', http_build_query($params)))
             ->json();
         
-            dump($response);
         return $response['no_of_contacts'] ?? 0;
     }
 

--- a/src/Api/ZohoCampaignsApi.php
+++ b/src/Api/ZohoCampaignsApi.php
@@ -29,7 +29,7 @@ class ZohoCampaignsApi
             ], $contactInfo)),
         ], $additionalParams);
         
-        dump(params);
+        dump($params);
 
         return Http::baseUrl($this->endpoint())
             ->withToken($this->accessToken->get(), 'Zoho-oauthtoken')

--- a/src/Api/ZohoCampaignsApi.php
+++ b/src/Api/ZohoCampaignsApi.php
@@ -28,7 +28,9 @@ class ZohoCampaignsApi
                 'Contact Email' => $email,
             ], $contactInfo)),
         ], $additionalParams);
-    
+        
+        dump(params);
+
         return Http::baseUrl($this->endpoint())
             ->withToken($this->accessToken->get(), 'Zoho-oauthtoken')
             ->withHeaders([

--- a/src/Campaigns.php
+++ b/src/Campaigns.php
@@ -59,7 +59,7 @@ class Campaigns
     {
         $listKey = $this->resolveListKey($listName);
 
-        $additionalParams = ['donotmail_resub' => true];
+        $additionalParams = ['donotmail_resub' => 'true'];
 
         $response = $this->zohoApi->listSubscribe($listKey, $email, $contactInfo, $additionalParams);
 

--- a/src/Campaigns.php
+++ b/src/Campaigns.php
@@ -51,6 +51,25 @@ class Campaigns
         ];
     }
 
+
+    /**
+     * @return array{success: bool, message?: string}
+     */
+    public function resubscribe(string $email, ?array $contactInfo = [], string $listName = null): array
+    {
+        $listKey = $this->resolveListKey($listName);
+
+        $additionalParams = ['donotmail_resub' => true];
+
+        $response = $this->zohoApi->listSubscribe($listKey, $email, $contactInfo, $additionalParams);
+
+        return [
+            'success' => Arr::get($response, 'status') === 'success',
+            'message' => Arr::get($response, 'message'),
+        ];
+    }
+
+
     protected function resolveListKey(?string $listName = null): string
     {
         $listName = $listName ?? $this->defaultListName;

--- a/src/Campaigns.php
+++ b/src/Campaigns.php
@@ -88,6 +88,21 @@ class Campaigns
     }
 
 
+    /**
+     * Retrieves the count of subscribers for a given list name and status.
+     *
+     * @param string|null $listName The name of the list. If null, the default list name will be used.
+     * @param string $status The status of the subscribers to count. Possible values are 'active', 'unsub', 'bounce', and 'spam'.
+     * @return int The count of subscribers.
+     */
+    public function countSubscribers(?string $listName = null, string $status = 'active'): int
+    {
+        $listKey = $this->resolveListKey($listName);
+
+        return $this->zohoApi->getListSubscribersCount($listKey, $status);
+    }
+
+
     protected function resolveListKey(?string $listName = null): string
     {
         $listName = $listName ?? $this->defaultListName;

--- a/src/Campaigns.php
+++ b/src/Campaigns.php
@@ -69,6 +69,24 @@ class Campaigns
         ];
     }
 
+    /**
+     * Retrieves subscribers for a given list name.
+     *
+     * @param string|null $listName The name of the list. If null, the default list name will be used.
+     * @param array $options An array of options for the request. Possible keys include:
+     *     - 'sort': The sort order of the results. Possible values are 'asc' for ascending order and 'desc' for descending order.
+     *     - 'fromindex': The starting index for the results. This is a number.
+     *     - 'range': The range of results to retrieve. This is a number.
+     *     - 'status': The status of the subscribers to retrieve. Possible values are 'active', 'recent', 'mostrecent', 'unsub', and 'bounce'.
+     * @return array The list of subscribers.
+     */
+    public function getSubscribers(?string $listName = null, array $options = []): array
+    {
+        $listKey = $this->resolveListKey($listName);
+
+        return $this->zohoApi->getListSubscribers($listKey, $options);
+    }
+
 
     protected function resolveListKey(?string $listName = null): string
     {

--- a/src/Facades/Campaigns.php
+++ b/src/Facades/Campaigns.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static array|null subscribe(string $email, ?array $contactInfo = [], string $listName = null)
  * @method static array|null resubscribe(string $email, ?array $contactInfo = [], string $listName = null)
  * @method static array|null unsubscribe(string $email, string $listName = null)
+ * @method static array|null getSubscribers(?string $listName = null, array $options = [])
  *
  * @see \Keepsuit\Campaigns\Campaigns
  */

--- a/src/Facades/Campaigns.php
+++ b/src/Facades/Campaigns.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static array|null subscribe(string $email, ?array $contactInfo = [], string $listName = null)
+ * @method static array|null resubscribe(string $email, ?array $contactInfo = [], string $listName = null)
  * @method static array|null unsubscribe(string $email, string $listName = null)
  *
  * @see \Keepsuit\Campaigns\Campaigns

--- a/src/Facades/Campaigns.php
+++ b/src/Facades/Campaigns.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static array|null resubscribe(string $email, ?array $contactInfo = [], string $listName = null)
  * @method static array|null unsubscribe(string $email, string $listName = null)
  * @method static array|null getSubscribers(?string $listName = null, array $options = [])
+ * @method static array|null countSubscribers(?string $listName = null, string $status = 'active')
  *
  * @see \Keepsuit\Campaigns\Campaigns
  */


### PR DESCRIPTION
If the user is unsubscribed Zoho allows only resubscription via form.
The subscription response returns true for success but the message is "Contact belongs to Do-not-mail registry." and user does not receive any confirmation emails and is not subscribed again.

To allow re-subscription a specific parameter has to be added to the request url 
donotmail_resub=true

With this parameter the response message is the following 
"This is a Donotmail contact or removed contact,So the resubscribtion email is sent to the user. User needs to confirm to successfully subscribe."
And  user receives a resubscription confirmation email.

With this pull request resubscribe method is added that works.