### PR TITLE
Add support for specifying list via list key

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ Campaigns::subscribe('user_a@example.com', contactInfo: [
 // on a specific list:
 Campaigns::subscribe('user_a@example.com', contactInfo: [], listName: 'listName');
 
+// on a specific list via list key
+Campaigns::subscribe('user_a@example.com', contactInfo: [], listKey: '3z9d17e6b4f3a2c5d8a1bc9478df32561e3ab4d2c4fc7a5e9c0db8e34176ca92a0');
+
 // if user previously unsubscribed from the list, you can resubscribe them (it support the same parameters as subscribe):
 Campaigns::resubscribe('user_a@example.com');
 ```

--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ Campaigns::subscribe('user_a@example.com', contactInfo: [
 ]);
 
 // on a specific list:
-Campaigns::subscribe('user_a@example.com', contactInfo: [], listName: 'listName');
+Campaigns::subscribe('user_a@example.com', contactInfo: [], list: 'listName');
 
 // on a specific list via list key
-Campaigns::subscribe('user_a@example.com', contactInfo: [], listKey: '3z9d17e6b4f3a2c5d8a1bc9478df32561e3ab4d2c4fc7a5e9c0db8e34176ca92a0');
+Campaigns::subscribe('user_a@example.com', contactInfo: [], list: '3z9d17e6b4f3a2c5d8a1bc9478df32561e3ab4d2c4fc7a5e9c0db8e34176ca92a0');
 
 // if user previously unsubscribed from the list, you can resubscribe them (it support the same parameters as subscribe):
 Campaigns::resubscribe('user_a@example.com');
@@ -133,7 +133,10 @@ use Keepsuit\Campaigns\Facades\Campaigns;
 Campaigns::unsubscribe('user_a@example.com');
 
 // from a specific list:
-Campaigns::unsubscribe('user_a@example.com', listName: 'listName');
+Campaigns::unsubscribe('user_a@example.com', list: 'listName');
+
+// on a specific list via list key
+Campaigns::unsubscribe('user_a@example.com', list: '3z9d17e6b4f3a2c5d8a1bc9478df32561e3ab4d2c4fc7a5e9c0db8e34176ca92a0');
 ```
 
 ### Get subscribers from a list
@@ -146,7 +149,10 @@ use Keepsuit\Campaigns\Facades\Campaigns;
 Campaigns::subscribers(status: 'active', sort: 'desc');
 
 // from a specific list:
-Campaigns::subscribers(listName: 'listName');
+Campaigns::subscribers(list: 'listName');
+
+// on a specific list via list key
+Campaigns::subscribers(list: '3z9d17e6b4f3a2c5d8a1bc9478df32561e3ab4d2c4fc7a5e9c0db8e34176ca92a0');
 ```
 
 ### Get subscribers count of a list
@@ -158,7 +164,10 @@ use Keepsuit\Campaigns\Facades\Campaigns;
 Campaigns::subscribersCount(status: 'active');
 
 // from a specific list:
-Campaigns::subscribersCount(listName: 'listName');
+Campaigns::subscribersCount(list: 'listName');
+
+// on a specific list via list key
+Campaigns::subscribersCount(list: '3z9d17e6b4f3a2c5d8a1bc9478df32561e3ab4d2c4fc7a5e9c0db8e34176ca92a0');
 ```
 
 ## Testing

--- a/src/Campaigns.php
+++ b/src/Campaigns.php
@@ -31,9 +31,9 @@ class Campaigns
      * @throws ConnectionException
      * @throws ZohoApiException
      */
-    public function subscribe(string $email, array $contactInfo = [], ?string $listName = null): string
+    public function subscribe(string $email, array $contactInfo = [], ?string $listName = null, ?string $listKey = null): string
     {
-        $listKey = $this->resolveListKey($listName);
+        $listKey = $listKey ?? $this->resolveListKey($listName);
 
         return $this->zohoApi->listSubscribe($listKey, $email, $contactInfo);
     }
@@ -42,9 +42,9 @@ class Campaigns
      * @throws ConnectionException
      * @throws ZohoApiException
      */
-    public function resubscribe(string $email, array $contactInfo = [], ?string $listName = null): string
+    public function resubscribe(string $email, array $contactInfo = [], ?string $listName = null, ?string $listKey = null): string
     {
-        $listKey = $this->resolveListKey($listName);
+        $listKey = $listKey ?? $this->resolveListKey($listName);
 
         $additionalParams = ['donotmail_resub' => 'true'];
 
@@ -55,9 +55,9 @@ class Campaigns
      * @throws ConnectionException
      * @throws ZohoApiException
      */
-    public function unsubscribe(string $email, ?string $listName = null): string
+    public function unsubscribe(string $email, ?string $listName = null, ?string $listKey = null): string
     {
-        $listKey = $this->resolveListKey($listName);
+        $listKey = $listKey ?? $this->resolveListKey($listName);
 
         return $this->zohoApi->listUnsubscribe($listKey, $email);
     }
@@ -74,12 +74,12 @@ class Campaigns
      * @throws ConnectionException
      * @throws ZohoApiException
      */
-    public function subscribers(string $status = 'active', string $sort = 'asc', int $chunkSize = 500, ?string $listName = null): LazyCollection
+    public function subscribers(string $status = 'active', string $sort = 'asc', int $chunkSize = 500, ?string $listName = null, ?string $listKey = null): LazyCollection
     {
         // Zoho API has a limit of 650 subscribers per request.
         $chunkSize = min(650, max(1, $chunkSize));
 
-        $listKey = $this->resolveListKey($listName);
+        $listKey = $listKey ?? $this->resolveListKey($listName);
 
         return LazyCollection::make(function () use ($status, $sort, $listKey, $chunkSize) {
             $fromIndex = 1;
@@ -119,9 +119,9 @@ class Campaigns
      * @throws ConnectionException
      * @throws ZohoApiException
      */
-    public function subscribersCount(string $status = 'active', ?string $listName = null): int
+    public function subscribersCount(string $status = 'active', ?string $listName = null, ?string $listKey = null): int
     {
-        $listKey = $this->resolveListKey($listName);
+        $listKey = $listKey ?? $this->resolveListKey($listName);
 
         return $this->zohoApi->listSubscribersCount($listKey, $status);
     }

--- a/src/Campaigns.php
+++ b/src/Campaigns.php
@@ -132,10 +132,10 @@ class Campaigns
 
         $listKey = Arr::get($this->lists->get($listName, []), 'listKey');
 
-        if ($listKey !== null || $list !== null) {
-            return $listKey ?? $list;
+        if ($listKey === null && $list === null) {
+            throw new \RuntimeException(sprintf('Cannot resolve list %s', $listName));
         }
 
-        throw new \Error(sprintf('Cannot resolve list %s', $listName));
+        return $listKey ?? $list;
     }
 }

--- a/src/Facades/Campaigns.php
+++ b/src/Facades/Campaigns.php
@@ -8,11 +8,11 @@ use Illuminate\Support\LazyCollection;
 /**
  * @phpstan-import-type ZohoCustomer from \Keepsuit\Campaigns\Api\ZohoCampaignsApi
  *
- * @method static string subscribe(string $email, array $contactInfo = [], string $list = null)
- * @method static string resubscribe(string $email, array $contactInfo = [], string $list = null)
- * @method static string unsubscribe(string $email, string $list = null)
- * @method static LazyCollection<array-key, ZohoCustomer> subscribers(string $status = 'active', string $sort = 'asc', int $chunkSize = 500, string $list = null)
- * @method static int subscribersCount(string $status = 'active', string $list = null)
+ * @method static string subscribe(string $email, array $contactInfo = [], ?string $list = null)
+ * @method static string resubscribe(string $email, array $contactInfo = [], ?string $list = null)
+ * @method static string unsubscribe(string $email, ?string $list = null)
+ * @method static LazyCollection<array-key, ZohoCustomer> subscribers(string $status = 'active', string $sort = 'asc', int $chunkSize = 500, ?string $list = null)
+ * @method static int subscribersCount(string $status = 'active', ?string $list = null)
  *
  * @see \Keepsuit\Campaigns\Campaigns
  */

--- a/src/Facades/Campaigns.php
+++ b/src/Facades/Campaigns.php
@@ -8,11 +8,11 @@ use Illuminate\Support\LazyCollection;
 /**
  * @phpstan-import-type ZohoCustomer from \Keepsuit\Campaigns\Api\ZohoCampaignsApi
  *
- * @method static string subscribe(string $email, array $contactInfo = [], string $listName = null)
- * @method static string resubscribe(string $email, array $contactInfo = [], string $listName = null)
- * @method static string unsubscribe(string $email, string $listName = null)
- * @method static LazyCollection<array-key, ZohoCustomer> subscribers(string $status = 'active', string $sort = 'asc', int $chunkSize = 500, ?string $listName = null)
- * @method static int subscribersCount(string $status = 'active', ?string $listName = null)
+ * @method static string subscribe(string $email, array $contactInfo = [], string $listName = null, string $listKey = null)
+ * @method static string resubscribe(string $email, array $contactInfo = [], string $listName = null, string $listKey = null)
+ * @method static string unsubscribe(string $email, string $listName = null, string $listKey = null)
+ * @method static LazyCollection<array-key, ZohoCustomer> subscribers(string $status = 'active', string $sort = 'asc', int $chunkSize = 500, ?string $listName = null, ?string $listKey = null)
+ * @method static int subscribersCount(string $status = 'active', ?string $listName = null, ?string $listKey = null)
  *
  * @see \Keepsuit\Campaigns\Campaigns
  */

--- a/src/Facades/Campaigns.php
+++ b/src/Facades/Campaigns.php
@@ -8,11 +8,11 @@ use Illuminate\Support\LazyCollection;
 /**
  * @phpstan-import-type ZohoCustomer from \Keepsuit\Campaigns\Api\ZohoCampaignsApi
  *
- * @method static string subscribe(string $email, array $contactInfo = [], string $listName = null, string $listKey = null)
- * @method static string resubscribe(string $email, array $contactInfo = [], string $listName = null, string $listKey = null)
- * @method static string unsubscribe(string $email, string $listName = null, string $listKey = null)
- * @method static LazyCollection<array-key, ZohoCustomer> subscribers(string $status = 'active', string $sort = 'asc', int $chunkSize = 500, ?string $listName = null, ?string $listKey = null)
- * @method static int subscribersCount(string $status = 'active', ?string $listName = null, ?string $listKey = null)
+ * @method static string subscribe(string $email, array $contactInfo = [], string $list = null)
+ * @method static string resubscribe(string $email, array $contactInfo = [], string $list = null)
+ * @method static string unsubscribe(string $email, string $list = null)
+ * @method static LazyCollection<array-key, ZohoCustomer> subscribers(string $status = 'active', string $sort = 'asc', int $chunkSize = 500, string $list = null)
+ * @method static int subscribersCount(string $status = 'active', string $list = null)
  *
  * @see \Keepsuit\Campaigns\Campaigns
  */

--- a/tests/Unit/CampaignsFacadeTest.php
+++ b/tests/Unit/CampaignsFacadeTest.php
@@ -19,6 +19,19 @@ it('can subscribe user to a list', function () {
     expect($response)->toBe('User subscribed successfully');
 });
 
+it('can subscribe user to a list with list key', function () {
+    $campaignsApi = mock(ZohoCampaignsApi::class);
+    $campaignsApi->shouldReceive('listSubscribe')
+        ->with('custom-list-key', 'test@example.com', [])
+        ->andReturn('User subscribed successfully');
+
+    app()->bind(ZohoCampaignsApi::class, fn () => $campaignsApi);
+
+    $response = Campaigns::subscribe('test@example.com', list: 'custom-list-key');
+
+    expect($response)->toBe('User subscribed successfully');
+});
+
 it('can resubscribe user to a list', function () {
     $campaignsApi = mock(ZohoCampaignsApi::class);
     $campaignsApi->shouldReceive('listSubscribe')


### PR DESCRIPTION
Hi thanks for the package!

We have a need to allow our CMS editors to directly configure the lists, so to enable this we just need the ability to pass the listKey directly